### PR TITLE
downlink protocol version option and bump

### DIFF
--- a/src/Config.lua
+++ b/src/Config.lua
@@ -13,6 +13,7 @@ CONFIG["GW_ALT"]=0
 CONFIG["GW_NSS"]=0
 CONFIG["GW_DIO0"]=1
 CONFIG["GW_DIO1"]=2
+CONFIG["GW_PROTO_VERSION"]=0x02
 
 local function printConfig()
   print("Configuration")
@@ -29,6 +30,7 @@ local function printConfig()
   print("\tGW_NSS     ",CONFIG["GW_NSS"])
   print("\tGW_DIO0    ",CONFIG["GW_DIO0"])
   print("\tGW_DIO1    ",CONFIG["GW_DIO1"])
+  print("\tGW_PROTO_VERSION ",CONFIG["GW_PROTO_VERSION"])
 end
 
 local function saveConfig()
@@ -54,6 +56,10 @@ if file.exists('config.json') then
     CONFIG["GW_NTP_SERVER"]="nl.pool.ntp.org"
     saveConfig()
   end
+  if (not CONFIG["GW_PROTO_VERSION"]) then
+    CONFIG["GW_PROTO_VERSION"]=0x02
+    saveConfig()
+  end  
 else
   print("no config found, using default values")
 end

--- a/src/LoRaWanGW.lua
+++ b/src/LoRaWanGW.lua
@@ -56,7 +56,7 @@ local function header(pkgType,r1,r2)
   if r1 == nil then r1=math.random(256)-1 end
   if r2 == nil then r2=math.random(256)-1 end
   return string.char(
-    0x01, --ProtocolVersion
+    CONFIG["GW_PROTO_VERSION"], --ProtocolVersion
     r1, -- RandomSeed
     r2, -- RandomSeed
     pkgType


### PR DESCRIPTION
The Things Network router is no longer answering for version 1 udp pooling.
https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT
https://www.thethingsnetwork.org/wiki/FAQ#frequently-asked-questions_what-about-all-those-different-versions-of-the-backend